### PR TITLE
Support bare domains and paged domains

### DIFF
--- a/lib/do-api.js
+++ b/lib/do-api.js
@@ -1,7 +1,8 @@
 const fetch = require('node-fetch')
 
-module.exports.listDomainRecords = ({ token, domainName }) =>
-  jsonFetch(`https://api.digitalocean.com/v2/domains/${domainName}/records`, {
+
+module.exports.listDomainRecords = ({ token, domainName, ...rest }) =>
+  jsonFetch(`https://api.digitalocean.com/v2/domains/${domainName}/records${appendQuery(rest)}`, {
     token,
     method: 'GET'
   }).then(res => res.domain_records)
@@ -53,4 +54,10 @@ async function jsonFetch (url, { method, token, body }) {
   }
 
   return res.json()
+}
+
+
+function appendQuery(queryVariables) {
+  const queryString = new URLSearchParams(queryVariables).toString();
+  return queryString === '' ? '' : `?${queryString};`
 }

--- a/lib/do-api.js
+++ b/lib/do-api.js
@@ -1,6 +1,9 @@
 const fetch = require('node-fetch')
 
 
+/**
+ *  https://docs.digitalocean.com/reference/api/api-reference/#operation/domains_list_records
+ */
 module.exports.listDomainRecords = ({ token, domainName, ...rest }) =>
   jsonFetch(`https://api.digitalocean.com/v2/domains/${domainName}/records${appendQuery(rest)}`, {
     token,

--- a/lib/update-domain.js
+++ b/lib/update-domain.js
@@ -49,12 +49,19 @@ module.exports = function build () {
   }
 
   async function getExistingDomainRecord (opts) {
-    log.info('Fetch existing Domain records')
+    log.info("Fetch existing Domain records");
     const domainRecords = await api.listDomainRecords({
       token: opts.token,
-      domainName: opts.domainName
-    })
-    return domainRecords.find(r => r.name === opts.recordName) || false
+      domainName: opts.domainName,
+      type: opts.recordType,
+      name:
+        opts.recordName === "@"
+          ? opts.domainName
+          : `${opts.recordName}.${opts.domainName}`,
+    });
+    return (
+      domainRecords.find((r) => r.name === opts.recordName) || false
+    );
   }
 
   async function createDomainRecord (opts) {


### PR DESCRIPTION
 - Adds support for using querystring parameters with digital ocean APIs
 - Uses query parameters to filter the listings of existing domains

I was having issues using a `-r @` record to associate a bare domain. I was also having problems with the tool trying to update records of a different type with the same domain (e.g. `TXT`).